### PR TITLE
Merge tag 'android-security-13.0.0_r22' into arrow-13.1

### DIFF
--- a/android/app/jni/com_android_bluetooth_hid_host.cpp
+++ b/android/app/jni/com_android_bluetooth_hid_host.cpp
@@ -282,7 +282,8 @@ static jboolean connectHidNative(JNIEnv* env, jobject object,
 }
 
 static jboolean disconnectHidNative(JNIEnv* env, jobject object,
-                                    jbyteArray address) {
+                                    jbyteArray address,
+                                    jboolean reconnect_allowed) {
   jbyte* addr;
   jboolean ret = JNI_TRUE;
   if (!sBluetoothHidInterface) return JNI_FALSE;
@@ -293,7 +294,8 @@ static jboolean disconnectHidNative(JNIEnv* env, jobject object,
     return JNI_FALSE;
   }
 
-  bt_status_t status = sBluetoothHidInterface->disconnect((RawAddress*)addr);
+  bt_status_t status =
+      sBluetoothHidInterface->disconnect((RawAddress*)addr, reconnect_allowed);
   if (status != BT_STATUS_SUCCESS) {
     ALOGE("Failed disconnect hid channel, status: %d", status);
     ret = JNI_FALSE;
@@ -509,7 +511,7 @@ static JNINativeMethod sMethods[] = {
     {"initializeNative", "()V", (void*)initializeNative},
     {"cleanupNative", "()V", (void*)cleanupNative},
     {"connectHidNative", "([B)Z", (void*)connectHidNative},
-    {"disconnectHidNative", "([B)Z", (void*)disconnectHidNative},
+    {"disconnectHidNative", "([BZ)Z", (void*)disconnectHidNative},
     {"getProtocolModeNative", "([B)Z", (void*)getProtocolModeNative},
     {"virtualUnPlugNative", "([B)Z", (void*)virtualUnPlugNative},
     {"setProtocolModeNative", "([BB)Z", (void*)setProtocolModeNative},

--- a/android/app/src/com/android/bluetooth/hid/HidHostService.java
+++ b/android/app/src/com/android/bluetooth/hid/HidHostService.java
@@ -186,7 +186,10 @@ public class HidHostService extends ProfileService {
                 break;
                 case MESSAGE_DISCONNECT: {
                     BluetoothDevice device = (BluetoothDevice) msg.obj;
-                    if (!disconnectHidNative(getByteAddress(device))) {
+                    int connectionPolicy = getConnectionPolicy(device);
+                    boolean reconnectAllowed =
+                            connectionPolicy == BluetoothProfile.CONNECTION_POLICY_ALLOWED;
+                    if (!disconnectHidNative(getByteAddress(device), reconnectAllowed)) {
                         broadcastConnectionState(device, BluetoothProfile.STATE_DISCONNECTING);
                         broadcastConnectionState(device, BluetoothProfile.STATE_DISCONNECTED);
                         break;
@@ -1023,7 +1026,7 @@ public class HidHostService extends ProfileService {
 
     private native boolean connectHidNative(byte[] btAddress);
 
-    private native boolean disconnectHidNative(byte[] btAddress);
+    private native boolean disconnectHidNative(byte[] btAddress, boolean reconnectAllowed);
 
     private native boolean getProtocolModeNative(byte[] btAddress);
 

--- a/system/btif/include/btif_hh.h
+++ b/system/btif/include/btif_hh.h
@@ -106,6 +106,7 @@ typedef struct {
   uint8_t dev_handle;
   RawAddress bd_addr;
   tBTA_HH_ATTR_MASK attr_mask;
+  bool reconnect_allowed;
 } btif_hh_added_device_t;
 
 /**
@@ -130,7 +131,8 @@ extern btif_hh_cb_t btif_hh_cb;
 extern btif_hh_device_t* btif_hh_find_connected_dev_by_handle(uint8_t handle);
 extern void btif_hh_remove_device(RawAddress bd_addr);
 extern bool btif_hh_add_added_dev(const RawAddress& bda,
-                                  tBTA_HH_ATTR_MASK attr_mask);
+                                  tBTA_HH_ATTR_MASK attr_mask,
+                                  bool reconnect_allowed);
 extern bt_status_t btif_hh_virtual_unplug(const RawAddress* bd_addr);
 extern void btif_hh_disconnect(RawAddress* bd_addr);
 extern void btif_hh_setreport(btif_hh_device_t* p_dev,

--- a/system/btif/include/btif_storage.h
+++ b/system/btif/include/btif_storage.h
@@ -200,6 +200,29 @@ bt_status_t btif_storage_load_bonded_devices(void);
 
 /*******************************************************************************
  *
+ * Function         btif_storage_set_hid_connection_policy
+ *
+ * Description      Stores connection policy info in nvram
+ *
+ * Returns          BT_STATUS_SUCCESS
+ *
+ ******************************************************************************/
+bt_status_t btif_storage_set_hid_connection_policy(const RawAddress& addr,
+                                                   bool reconnect_allowed);
+/*******************************************************************************
+ *
+ * Function         btif_storage_get_hid_connection_policy
+ *
+ * Description      get connection policy info from nvram
+ *
+ * Returns          BT_STATUS_SUCCESS
+ *
+ ******************************************************************************/
+bt_status_t btif_storage_get_hid_connection_policy(const RawAddress& addr,
+                                                   bool* reconnect_allowed);
+
+/*******************************************************************************
+ *
  * Function         btif_storage_add_hid_device_info
  *
  * Description      BTIF storage API - Adds the hid information of bonded hid

--- a/system/btif/src/btif_storage.cc
+++ b/system/btif/src/btif_storage.cc
@@ -114,6 +114,8 @@ using bluetooth::groups::DeviceGroups;
 #define BTIF_STORAGE_LEAUDIO_SOURCE_SUPPORTED_CONTEXT_TYPE \
   "SourceSupportedContextType"
 
+#define BTIF_STORAGE_KEY_HID_RECONNECT_ALLOWED "HidReConnectAllowed"
+
 /* This is a local property to add a device found */
 #define BT_PROPERTY_REMOTE_DEVICE_TIMESTAMP 0xFF
 
@@ -1515,6 +1517,49 @@ bool btif_storage_get_remote_device_type(const RawAddress& remote_bd_addr,
 
 /*******************************************************************************
  *
+ * Function         btif_storage_set_hid_connection_policy
+ *
+ * Description      Stores connection policy info in nvram
+ *
+ * Returns          BT_STATUS_SUCCESS
+ *
+ ******************************************************************************/
+bt_status_t btif_storage_set_hid_connection_policy(const RawAddress& addr,
+                                                   bool reconnect_allowed) {
+  std::string bdstr = addr.ToString();
+
+  if (btif_config_set_int(bdstr, BTIF_STORAGE_KEY_HID_RECONNECT_ALLOWED,
+                          reconnect_allowed)) {
+    return BT_STATUS_SUCCESS;
+  } else {
+    return BT_STATUS_FAIL;
+  }
+}
+
+/*******************************************************************************
+ *
+ * Function         btif_storage_get_hid_connection_policy
+ *
+ * Description      get connection policy info from nvram
+ *
+ * Returns          BT_STATUS_SUCCESS
+ *
+ ******************************************************************************/
+bt_status_t btif_storage_get_hid_connection_policy(const RawAddress& addr,
+                                                   bool* reconnect_allowed) {
+  std::string bdstr = addr.ToString();
+
+  // For backward compatibility, assume that the reconnection is allowed in the
+  // absence of the key
+  int value = 1;
+  btif_config_get_int(bdstr, BTIF_STORAGE_KEY_HID_RECONNECT_ALLOWED, &value);
+  *reconnect_allowed = (value != 0);
+
+  return BT_STATUS_SUCCESS;
+}
+
+/*******************************************************************************
+ *
  * Function         btif_storage_add_hid_device_info
  *
  * Description      BTIF storage API - Adds the hid information of bonded hid
@@ -1608,8 +1653,11 @@ bt_status_t btif_storage_load_bonded_hid_info(void) {
                           (uint8_t*)dscp_info.descriptor.dsc_list, &len);
     }
 
+    bool reconnect_allowed = false;
+    btif_storage_get_hid_connection_policy(bd_addr, &reconnect_allowed);
+
     // add extracted information to BTA HH
-    if (btif_hh_add_added_dev(bd_addr, attr_mask)) {
+    if (btif_hh_add_added_dev(bd_addr, attr_mask, reconnect_allowed)) {
       BTA_HhAddDev(bd_addr, attr_mask, sub_class, app_id, dscp_info);
     }
   }
@@ -1641,6 +1689,7 @@ bt_status_t btif_storage_remove_hid_info(const RawAddress& remote_bd_addr) {
   btif_config_remove(bdstr, "HidSSRMaxLatency");
   btif_config_remove(bdstr, "HidSSRMinTimeout");
   btif_config_remove(bdstr, "HidDescriptor");
+  btif_config_remove(bdstr, BTIF_STORAGE_KEY_HID_RECONNECT_ALLOWED);
   btif_config_save();
   return BT_STATUS_SUCCESS;
 }

--- a/system/gd/rust/linux/stack/src/bluetooth.rs
+++ b/system/gd/rust/linux/stack/src/bluetooth.rs
@@ -1412,7 +1412,7 @@ impl IBluetooth for Bluetooth {
                     if self.uuid_helper.is_profile_enabled(&p) {
                         match p {
                             Profile::Hid | Profile::Hogp => {
-                                self.hh.as_ref().unwrap().disconnect(&mut addr.unwrap());
+                                self.hh.as_ref().unwrap().disconnect(&mut addr.unwrap(), true);
                             }
 
                             Profile::A2dpSink | Profile::A2dpSource => {

--- a/system/gd/rust/topshim/src/profiles/hid_host.rs
+++ b/system/gd/rust/topshim/src/profiles/hid_host.rs
@@ -208,7 +208,7 @@ impl HidHost {
 
     pub fn disconnect(&self, addr: &mut RawAddress) -> BtStatus {
         let ffi_addr = cast_to_ffi_address!(addr as *mut RawAddress);
-        BtStatus::from(ccall!(self, disconnect, ffi_addr))
+        BtStatus::from(ccall!(self, disconnect, ffi_addr, true))
     }
 
     pub fn virtual_unplug(&self, addr: &mut RawAddress) -> BtStatus {

--- a/system/include/hardware/bt_hh.h
+++ b/system/include/hardware/bt_hh.h
@@ -173,7 +173,7 @@ typedef struct {
   bt_status_t (*connect)(RawAddress* bd_addr);
 
   /** dis-connect from hid device */
-  bt_status_t (*disconnect)(RawAddress* bd_addr);
+  bt_status_t (*disconnect)(RawAddress* bd_addr, bool reconnect_allowed);
 
   /** Virtual UnPlug (VUP) the specified HID device */
   bt_status_t (*virtual_unplug)(RawAddress* bd_addr);


### PR DESCRIPTION
HID profile accepted any new incoming HID connection. Even when the connection policy disabled HID connection, remote devices could initiate HID connection.
This change ensures that incoming HID connection are accepted only if application was interested in that HID connection. This vulnerarbility no longer exists on the main because of feature request b/324093729.

Test: mmm packages/modules/Bluetooth
Test: Manual | Pair and connect a HID device, disable HID connection from Bluetooth device setting, attempt to connect from the HID device. Bug: 308429049
Ignore-AOSP-First: security
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:03dca3305311096f157da3ab9cfed5cc30f2c135) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:431ef0346302dec8fa8c7d89c4696931e2bbac9a) Merged-In: I013d0528fb18ee87195fb3c8aab553c6a8da5ae4 Change-Id: I013d0528fb18ee87195fb3c8aab553c6a8da5ae4